### PR TITLE
Turn HTTP Error into an interface and add casting method

### DIFF
--- a/httperrors.go
+++ b/httperrors.go
@@ -8,7 +8,27 @@ import (
 
 // HTTPError is a replacement for the standard go error to be used in HTTP servers. It contains
 // extra information about the error like a response code and a stack trace.
-type HTTPError struct {
+type HTTPError interface {
+	// Error implements error interface. Responds with all messages wrapped in stack of HTTPErrors.
+	Error() string
+
+	// Message gets the outermost message
+	Message() string
+
+	// InnerMessage gets the innermost message
+	InnerMessage() string
+
+	// SetResponseCode sets the response code of this HTTPError
+	SetResponseCode(code int)
+
+	// ResponseCode gets the outermost response code
+	ResponseCode() int
+
+	// StackTrace gets the innermost available stacktrace
+	StackTrace() string
+}
+
+type baseHTTPError struct {
 	msg   string
 	code  int
 	stack string
@@ -20,14 +40,14 @@ const (
 	UninitializedResponseCode = -1
 )
 
-func (e *HTTPError) Error() string {
+func (e *baseHTTPError) Error() string {
 	errorMsgs := []string{
 		"ERROR:\t* " + e.msg,
 	}
 
 	inner := e.inner
 	for inner != nil {
-		httpError, ok := inner.(*HTTPError)
+		httpError, ok := inner.(*baseHTTPError)
 		if ok {
 			errorMsgs = append(errorMsgs, "\t* "+httpError.msg)
 			inner = httpError.inner
@@ -39,18 +59,16 @@ func (e *HTTPError) Error() string {
 	return strings.Join(errorMsgs, "\n")
 }
 
-// Message gets the outermost message
-func (e *HTTPError) Message() string {
+func (e *baseHTTPError) Message() string {
 	return e.msg
 }
 
-// InnerMessage gets the innermost message
-func (e *HTTPError) InnerMessage() string {
+func (e *baseHTTPError) InnerMessage() string {
 	var ok bool
-	var msgErr, nextMsgErr *HTTPError
+	var msgErr, nextMsgErr *baseHTTPError
 	msgErr = e
 	for msgErr.inner != nil {
-		nextMsgErr, ok = msgErr.inner.(*HTTPError)
+		nextMsgErr, ok = msgErr.inner.(*baseHTTPError)
 		if !ok {
 			return msgErr.inner.Error()
 		}
@@ -59,18 +77,16 @@ func (e *HTTPError) InnerMessage() string {
 	return msgErr.msg
 }
 
-// SetResponseCode sets the response code of this HTTPError
-func (e *HTTPError) SetResponseCode(code int) {
+func (e *baseHTTPError) SetResponseCode(code int) {
 	e.code = code
 }
 
-// ResponseCode gets the outermost response code
-func (e *HTTPError) ResponseCode() int {
+func (e *baseHTTPError) ResponseCode() int {
 	var ok bool
-	var codeErr, nextCodeErr *HTTPError
+	var codeErr, nextCodeErr *baseHTTPError
 	codeErr = e
 	for codeErr.code == UninitializedResponseCode {
-		nextCodeErr, ok = codeErr.inner.(*HTTPError)
+		nextCodeErr, ok = codeErr.inner.(*baseHTTPError)
 		if !ok {
 			return codeErr.code
 		}
@@ -79,13 +95,12 @@ func (e *HTTPError) ResponseCode() int {
 	return codeErr.code
 }
 
-// StackTrace gets the innermost available stacktrace
-func (e *HTTPError) StackTrace() string {
+func (e *baseHTTPError) StackTrace() string {
 	var ok bool
-	var stackErr, nextStackErr *HTTPError
+	var stackErr, nextStackErr *baseHTTPError
 	stackErr = e
 	for stackErr.inner != nil {
-		nextStackErr, ok = stackErr.inner.(*HTTPError)
+		nextStackErr, ok = stackErr.inner.(*baseHTTPError)
 		if !ok {
 			return stackErr.stack
 		}
@@ -94,16 +109,16 @@ func (e *HTTPError) StackTrace() string {
 	return stackErr.stack
 }
 
-// Wrap takes an existing error and turns it into a *HTTPError
-func Wrap(err error, msg string) *HTTPError {
-	resp := HTTPError{
+// Wrap takes an existing error and turns it into a HTTPError
+func Wrap(err error, msg string) HTTPError {
+	resp := baseHTTPError{
 		msg:   msg,
 		code:  UninitializedResponseCode,
 		inner: err,
 	}
 
 	// Wrap will only get a new stack trace if one does not exist
-	_, ok := err.(*HTTPError)
+	_, ok := err.(*baseHTTPError)
 	if !ok {
 		resp.stack = stackTrace()
 	}
@@ -111,33 +126,33 @@ func Wrap(err error, msg string) *HTTPError {
 }
 
 // Wrapf wraps an existing error with printf paramaters
-func Wrapf(err error, format string, args ...interface{}) *HTTPError {
-	resp := HTTPError{
+func Wrapf(err error, format string, args ...interface{}) HTTPError {
+	resp := baseHTTPError{
 		msg:   fmt.Sprintf(format, args...),
 		code:  UninitializedResponseCode,
 		inner: err,
 	}
 
 	// Wrap will only get a new stack trace if one does not exist
-	_, ok := err.(*HTTPError)
+	_, ok := err.(*baseHTTPError)
 	if !ok {
 		resp.stack = stackTrace()
 	}
 	return &resp
 }
 
-// New creates a new *HTTPError
-func New(msg string) *HTTPError {
-	return &HTTPError{
+// New creates a new HTTPError
+func New(msg string) HTTPError {
+	return &baseHTTPError{
 		msg:   msg,
 		code:  UninitializedResponseCode,
 		stack: stackTrace(),
 	}
 }
 
-// Newf creates a new *HTTPError with printf parameters
-func Newf(format string, args ...interface{}) *HTTPError {
-	return &HTTPError{
+// Newf creates a new HTTPError with printf parameters
+func Newf(format string, args ...interface{}) HTTPError {
+	return &baseHTTPError{
 		msg:   fmt.Sprintf(format, args...),
 		code:  UninitializedResponseCode,
 		stack: stackTrace(),

--- a/httperrors_test.go
+++ b/httperrors_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("HTTPError", func() {
 	var (
 		err                   error
-		outerHTTPErr, httpErr *HTTPError
+		outerHTTPErr, httpErr HTTPError
 	)
 
 	Describe("Creation", func() {
@@ -24,22 +24,14 @@ var _ = Describe("HTTPError", func() {
 			})
 
 			It("Wraps an error", func() {
-				Expect(httpErr.inner).To(Equal(err))
+				Expect(httpErr.InnerMessage()).To(Equal(err.Error()))
 			})
 			It("Wraps another HTTPError", func() {
-				Expect(outerHTTPErr.msg).To(Equal("outer http test err"))
-				Expect(outerHTTPErr.inner).To(Equal(httpErr))
-
-				tempErr, ok := outerHTTPErr.inner.(*HTTPError)
-				Expect(ok).To(BeTrue())
-				Expect(tempErr.inner).To(Equal(err))
+				Expect(outerHTTPErr.Message()).To(Equal("outer http test err"))
+				Expect(outerHTTPErr.InnerMessage()).To(Equal(err.Error()))
 			})
-			It("Only the innermost HTTPError has a stack trace", func() {
-				Expect(outerHTTPErr.stack).To(BeEmpty())
-
-				tempErr, ok := outerHTTPErr.inner.(*HTTPError)
-				Expect(ok).To(BeTrue())
-				Expect(tempErr.stack).ToNot(BeEmpty())
+			It("All levels of HTTPError have the same stack trace", func() {
+				Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.StackTrace()))
 			})
 		})
 
@@ -48,24 +40,24 @@ var _ = Describe("HTTPError", func() {
 				err = fmt.Errorf("test error")
 				httpErr = Wrapf(err, "%s test err", "http")
 
-				Expect(httpErr.msg).To(Equal("http test err"))
-				Expect(httpErr.inner).To(Equal(err))
+				Expect(httpErr.Message()).To(Equal("http test err"))
+				Expect(httpErr.InnerMessage()).To(Equal(err.Error()))
 			})
 		})
 
 		Describe("New", func() {
 			It("Creates a new HTTPError", func() {
 				httpErr = New("http test err")
-				Expect(httpErr.msg).To(Equal("http test err"))
-				Expect(httpErr.inner).To(BeNil())
+				Expect(httpErr.Message()).To(Equal("http test err"))
+				Expect(httpErr.InnerMessage()).To(Equal("http test err"))
 			})
 		})
 
 		Describe("Newf", func() {
 			It("Creates a new HTTPError with printf parameters", func() {
 				httpErr = Newf("%s test err", "http")
-				Expect(httpErr.msg).To(Equal("http test err"))
-				Expect(httpErr.inner).To(BeNil())
+				Expect(httpErr.Message()).To(Equal("http test err"))
+				Expect(httpErr.InnerMessage()).To(Equal("http test err"))
 			})
 		})
 	})
@@ -114,7 +106,7 @@ var _ = Describe("HTTPError", func() {
 
 		Describe("StackTrace", func() {
 			It("Gets the stack trace from the innermost HTTPError", func() {
-				Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.stack))
+				Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.StackTrace()))
 			})
 
 			Describe("strips out parts of the stack trace relating to httperrors library", func() {
@@ -147,7 +139,7 @@ var _ = Describe("HTTPError", func() {
 		})
 
 		It("Gets the innermost stack trace", func() {
-			Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.stack))
+			Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.StackTrace()))
 		})
 
 		It("Gets the innermost message", func() {

--- a/httperrors_test.go
+++ b/httperrors_test.go
@@ -10,54 +10,154 @@ import (
 
 var _ = Describe("HTTPError", func() {
 	var (
-		err                   error
-		outerHTTPErr, httpErr HTTPError
+		err          error
+		outerHTTPErr HTTPError
+		httpErr      HTTPError
+		emptyErr     HTTPError
+		castErr      HTTPError
 	)
 
-	Describe("Creation", func() {
+	Describe("Creating", func() {
 
-		Describe("Wrap", func() {
+		Describe("a wrapped error", func() {
 			BeforeEach(func() {
 				err = fmt.Errorf("test err")
 				httpErr = Wrap(err, "http test err")
 				outerHTTPErr = Wrap(httpErr, "outer http test err")
 			})
 
-			It("Wraps an error", func() {
+			It("gets the innermost message", func() {
 				Expect(httpErr.InnerMessage()).To(Equal(err.Error()))
-			})
-			It("Wraps another HTTPError", func() {
-				Expect(outerHTTPErr.Message()).To(Equal("outer http test err"))
 				Expect(outerHTTPErr.InnerMessage()).To(Equal(err.Error()))
 			})
-			It("All levels of HTTPError have the same stack trace", func() {
+			It("gets the outermost message", func() {
+				Expect(httpErr.Message()).To(Equal("http test err"))
+				Expect(outerHTTPErr.Message()).To(Equal("outer http test err"))
+			})
+			It("prints out the stack of error messages", func() {
+				Expect(httpErr.Error()).To(Equal("http test err\ntest err"))
+				Expect(outerHTTPErr.Error()).To(Equal("outer http test err\nhttp test err\ntest err"))
+			})
+			It("at any level has the same stack trace", func() {
 				Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.StackTrace()))
 			})
 		})
 
-		Describe("Wrapf", func() {
-			It("Wraps an error with printf parameters", func() {
-				err = fmt.Errorf("test error")
+		Describe("a wrapped error with printf parameters", func() {
+			BeforeEach(func() {
+				err = fmt.Errorf("test err")
 				httpErr = Wrapf(err, "%s test err", "http")
+				outerHTTPErr = Wrapf(httpErr, "%s test err", "outer http")
+			})
 
-				Expect(httpErr.Message()).To(Equal("http test err"))
+			It("gets the innermost message", func() {
 				Expect(httpErr.InnerMessage()).To(Equal(err.Error()))
+				Expect(outerHTTPErr.InnerMessage()).To(Equal(err.Error()))
+			})
+			It("gets the outermost message", func() {
+				Expect(httpErr.Message()).To(Equal("http test err"))
+				Expect(outerHTTPErr.Message()).To(Equal("outer http test err"))
+			})
+			It("prints out the stack of error messages", func() {
+				Expect(httpErr.Error()).To(Equal("http test err\ntest err"))
+				Expect(outerHTTPErr.Error()).To(Equal("outer http test err\nhttp test err\ntest err"))
+			})
+			It("at any level has the same stack trace", func() {
+				Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.StackTrace()))
 			})
 		})
 
-		Describe("New", func() {
-			It("Creates a new HTTPError", func() {
-				httpErr = New("http test err")
-				Expect(httpErr.Message()).To(Equal("http test err"))
-				Expect(httpErr.InnerMessage()).To(Equal("http test err"))
+		Describe("a new error", func() {
+			BeforeEach(func() {
+				httpErr = New("test err")
+			})
+
+			It("gets the innermost message", func() {
+				Expect(httpErr.InnerMessage()).To(Equal("test err"))
+			})
+			It("gets the outermost message", func() {
+				Expect(httpErr.Message()).To(Equal("test err"))
+			})
+			It("prints out the stack of error messages", func() {
+				Expect(httpErr.Error()).To(Equal("test err"))
+			})
+			It("has a stack trace", func() {
+				Expect(outerHTTPErr.StackTrace()).ToNot(Equal(UninitializedStackTrace))
 			})
 		})
 
-		Describe("Newf", func() {
-			It("Creates a new HTTPError with printf parameters", func() {
-				httpErr = Newf("%s test err", "http")
-				Expect(httpErr.Message()).To(Equal("http test err"))
-				Expect(httpErr.InnerMessage()).To(Equal("http test err"))
+		Describe("a new error with printf parameters", func() {
+			BeforeEach(func() {
+				httpErr = Newf("%s err", "test")
+			})
+
+			It("gets the innermost message", func() {
+				Expect(httpErr.InnerMessage()).To(Equal("test err"))
+			})
+			It("gets the outermost message", func() {
+				Expect(httpErr.Message()).To(Equal("test err"))
+			})
+			It("prints out the stack of error messages", func() {
+				Expect(httpErr.Error()).To(Equal("test err"))
+			})
+			It("has a stack trace", func() {
+				Expect(outerHTTPErr.StackTrace()).ToNot(Equal(UninitializedStackTrace))
+			})
+		})
+
+		Describe("an empty error", func() {
+			BeforeEach(func() {
+				emptyErr = New("")
+			})
+
+			It("has an unknown innermost message", func() {
+				Expect(emptyErr.InnerMessage()).To(Equal(UnknownErrorMsg))
+			})
+			It("has an unknown outermost message", func() {
+				Expect(emptyErr.Message()).To(Equal(UnknownErrorMsg))
+			})
+			It("prints out the stack of error messages", func() {
+				Expect(emptyErr.Error()).To(Equal(UnknownErrorMsg))
+			})
+			It("has a stack trace", func() {
+				Expect(emptyErr.StackTrace()).ToNot(Equal(UninitializedStackTrace))
+			})
+		})
+
+		Describe("a cast error", func() {
+			BeforeEach(func() {
+				err = fmt.Errorf("test err")
+				castErr = ToHTTPError(err)
+			})
+
+			It("gets the innermost message", func() {
+				Expect(httpErr.InnerMessage()).To(Equal("test err"))
+			})
+			It("gets the outermost message", func() {
+				Expect(httpErr.Message()).To(Equal("test err"))
+			})
+			It("prints out the stack of error messages", func() {
+				Expect(httpErr.Error()).To(Equal("test err"))
+			})
+			It("has a stack trace", func() {
+				Expect(outerHTTPErr.StackTrace()).ToNot(Equal(UninitializedStackTrace))
+			})
+		})
+
+		Describe("a cast HTTPError", func() {
+			It("gets the message", func() {
+				httpErr = New("test err")
+				castErr = ToHTTPError(httpErr)
+				Expect(castErr.Message()).To(Equal("test err"))
+			})
+		})
+
+		Describe("multiple layers of empty wrapped errors", func() {
+			It("gets the message", func() {
+				err = fmt.Errorf("test err")
+				httpErr = Wrap(err, "")
+				outerHTTPErr = Wrap(httpErr, "")
+				Expect(outerHTTPErr.Message()).To(Equal("test err"))
 			})
 		})
 	})
@@ -67,28 +167,6 @@ var _ = Describe("HTTPError", func() {
 			err = fmt.Errorf("test err")
 			httpErr = Wrap(err, "http test err")
 			outerHTTPErr = Wrap(httpErr, "outer http test err")
-		})
-
-		Describe("Error", func() {
-			It("Prints out wrapped errors in succession", func() {
-				Expect(err.Error()).To(Equal("test err"))
-				Expect(httpErr.Error()).To(Equal("ERROR:\t* http test err\n\t* test err"))
-				Expect(outerHTTPErr.Error()).To(Equal("ERROR:\t* outer http test err\n\t* http test err\n\t* test err"))
-			})
-		})
-
-		Describe("Message", func() {
-			It("Gets the outermost message", func() {
-				Expect(httpErr.Message()).To(Equal("http test err"))
-				Expect(outerHTTPErr.Message()).To(Equal("outer http test err"))
-			})
-		})
-
-		Describe("InnerMessage", func() {
-			It("Gets the innermost message", func() {
-				Expect(httpErr.InnerMessage()).To(Equal("test err"))
-				Expect(outerHTTPErr.InnerMessage()).To(Equal("test err"))
-			})
 		})
 
 		Describe("ResponseCode", func() {
@@ -132,7 +210,7 @@ var _ = Describe("HTTPError", func() {
 		})
 	})
 
-	Describe("Root error is HTTPError", func() {
+	Describe("a wrapped error where the root error is HTTPError", func() {
 		BeforeEach(func() {
 			httpErr = New("http test err")
 			outerHTTPErr = Wrap(httpErr, "outer http test err")


### PR DESCRIPTION
- Turn HTTPError into an interface
- Add "ToHTTPError" method to cast any standard or HTTPError into an HTTPError for processing
