### PR TITLE
Add error-codes to httperrors library.

### DIFF
--- a/httperrors_test.go
+++ b/httperrors_test.go
@@ -187,6 +187,24 @@ var _ = Describe("HTTPError", func() {
 			})
 		})
 
+		Describe("ErrorCode", func() {
+			It("Responds with UninitializedErrorCode if it has not been set", func() {
+				Expect(outerHTTPErr.ErrorCode()).To(Equal(UninitializedErrorCode))
+			})
+			It("Can use method chaining", func() {
+				chainedErr := New("test err").SetErrorCode("DUPLICATE")
+				Expect(chainedErr.ErrorCode()).To(Equal("DUPLICATE"))
+				Expect(chainedErr.Message()).To(Equal("test err"))
+			})
+			It("Responds with the outermost error code when set", func() {
+				httpErr.SetErrorCode("DUPLICATE")
+				Expect(outerHTTPErr.ErrorCode()).To(Equal("DUPLICATE"))
+
+				outerHTTPErr.SetErrorCode("INVALID")
+				Expect(outerHTTPErr.ErrorCode()).To(Equal("INVALID"))
+			})
+		})
+
 		Describe("StackTrace", func() {
 			It("Gets the stack trace from the innermost HTTPError", func() {
 				Expect(outerHTTPErr.StackTrace()).To(Equal(httpErr.StackTrace()))


### PR DESCRIPTION
Error codes are used to indicate a specific error type that can be processed by the calling entity. For instance, an error code could indicate that the values being submitted for creation are a duplicate and could handle appropriately. This prevents using the brittle pattern of string-comparing human readable error messages (that may be changed over time).
