### PR TITLE
(nil-wrap) Add the ability to pass nil into Wrap and Wrapf.

### DIFF
--- a/httperrors.go
+++ b/httperrors.go
@@ -183,8 +183,13 @@ func ToHTTPError(err error) HTTPError {
 	return httpErr
 }
 
-// Wrap takes an existing error and turns it into a HTTPError
+// Wrap takes an existing error and turns it into a HTTPError with a stacktrace.
+// Will return nil if err is nil.
 func Wrap(err error, msg string) HTTPError {
+	if err == nil {
+		return nil
+	}
+
 	resp := baseHTTPError{
 		msg:      msg,
 		respCode: UninitializedResponseCode,
@@ -199,8 +204,13 @@ func Wrap(err error, msg string) HTTPError {
 	return &resp
 }
 
-// Wrapf wraps an existing error with printf paramaters
+// Wrapf wraps an existing error with printf paramaters and turns it into a
+// HTT PError with a stacktrace. Will return nil if err is nil.
 func Wrapf(err error, format string, args ...interface{}) HTTPError {
+	if err == nil {
+		return nil
+	}
+
 	resp := baseHTTPError{
 		msg:      fmt.Sprintf(format, args...),
 		respCode: UninitializedResponseCode,

--- a/httperrors_test.go
+++ b/httperrors_test.go
@@ -18,6 +18,21 @@ var _ = Describe("HTTPError", func() {
 	)
 
 	Describe("Creating", func() {
+		Describe("wrapping a nil", func() {
+			BeforeEach(func() {
+				err = nil
+			})
+
+			It("should return nil for Wrap", func() {
+				httpErr = Wrap(err, "more context")
+				Expect(httpErr).To(BeNil())
+			})
+
+			It("should return nil for Wrapf", func() {
+				httpErr = Wrapf(err, "more %s", "context")
+				Expect(httpErr).To(BeNil())
+			})
+		})
 
 		Describe("a wrapped error", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
The functions will return nil if err is nil. This allows Wrap to be the final return of a function.
